### PR TITLE
Fix GOOGLE APPLICATION DEFAULT CREDENTIAL error

### DIFF
--- a/thumbor_cloud_storage/loaders/cloud_storage_loader.py
+++ b/thumbor_cloud_storage/loaders/cloud_storage_loader.py
@@ -9,14 +9,10 @@ from thumbor.loaders import LoaderResult
 from tornado.concurrent import return_future
 
 
+client = storage.Client()
+
 @return_future
 def load(context, path, callback):
-    try:
-        project_id = context.config.get("CLOUD_STORAGE_PROJECT_ID")
-    except KeyError:
-        project_id = os.environ['GOOGLE_CLOUD_PROJECT']
-    if not project_id:
-        project_id = os.environ['GOOGLE_CLOUD_PROJECT']
 
     result = LoaderResult()
 
@@ -32,7 +28,6 @@ def load(context, path, callback):
     path = _clean_path(path)
     file_path = path[prefix:]
 
-    client = storage.Client(project=project_id)
     bucket = client.bucket(bucket_id)
     blob = bucket.blob(file_path)
 


### PR DESCRIPTION
    Fixed:
    - Initialize storage object to only once --> fix GOOGLE_APPLICATION DEFAULT CREDENTIALS
      error, also thumbor response time will become faster
    Removed:
    - project_id: Not required, only need the bucket_id (bucket_id is unique
      on organization)

    Co-authored-by: Hilman Kurniawan <hilman.kurniawan@vidio.com>
    Co-authored-by: Hafidz Bahtiar <hafidz.bahtiar@vidio.com>